### PR TITLE
:technologist: Move compile_commands.json to source directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,3 @@ conanbuildinfo.txt
 
 # CMake
 CMakeUserPresets.json
-

--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -21,6 +21,13 @@ set(LIBHAL_SCRIPT_PATH ${CMAKE_CURRENT_LIST_DIR})
 # Generate compile commands for anyone using our libraries.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Always run this custom target by making it depend on ALL
+add_custom_target(copy_compile_commands ALL
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    ${CMAKE_BINARY_DIR}/compile_commands.json
+    ${CMAKE_SOURCE_DIR}/compile_commands.json
+    DEPENDS ${CMAKE_BINARY_DIR}/compile_commands.json)
+
 # Colored LIBHAL text
 set(LIBHAL_TITLE "${BoldMagenta}[LIBHAL]:${ColourReset}")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,7 @@ required_conan_version = ">=2.0.6"
 
 class libhal_cmake_util_conan(ConanFile):
     name = "libhal-cmake-util"
-    version = "4.0.4"
+    version = "4.0.5"
     license = "Apache-2.0"
     homepage = "https://libhal.github.io/libhal-armcortex"
     description = ("A collection of CMake scripts for ARM Cortex ")


### PR DESCRIPTION
This will allow the .clangd file to be simplified to checking the root directory for the package and the demo/ directory for the demo application. This will also automatically work for users using the root directory of a repo without a .clangd file (defaults to searching the root directory).