### PR TITLE
:bug: Order clang-tidy from highest to lowest

### DIFF
--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -42,7 +42,7 @@ if(WIN32)
 else()
   # Find clang-tidy "clang-tidy"
   find_program(LIBHAL_CLANG_TIDY_PROGRAM
-    NAMES "clang-tidy" "clang-tidy-17" "clang-tidy-18"
+    NAMES "clang-tidy-18" "clang-tidy-17" "clang-tidy"
     DOC "Path to clang-tidy executable")
 
   if(NOT LIBHAL_CLANG_TIDY_PROGRAM)

--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,7 @@ required_conan_version = ">=2.0.6"
 
 class libhal_cmake_util_conan(ConanFile):
     name = "libhal-cmake-util"
-    version = "4.1.3"
+    version = "4.1.4"
     license = "Apache-2.0"
     homepage = "https://libhal.github.io/libhal-armcortex"
     description = ("A collection of CMake scripts for ARM Cortex ")


### PR DESCRIPTION
This way, clang-tidy of the latest version is used then down to the lowest version being the wild card `clang-tidy`. If I can guarantee that `clang-tidy-17` is a command that is always available, I'll go with that.