### PR TITLE
:fire: Remove clang-tidy again

### DIFF
--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -36,40 +36,6 @@ add_custom_target(copy_compile_commands ALL
 # Colored LIBHAL text
 set(LIBHAL_TITLE "${BoldMagenta}[LIBHAL]:${ColourReset}")
 
-if(WIN32)
-  # Disable clang-tidy for Windows builds
-  set(CMAKE_CXX_CLANG_TIDY "")
-else()
-  # Find clang-tidy "clang-tidy"
-  find_program(LIBHAL_CLANG_TIDY_PROGRAM
-    NAMES "clang-tidy-18" "clang-tidy-17" "clang-tidy"
-    DOC "Path to clang-tidy executable")
-
-  if(NOT LIBHAL_CLANG_TIDY_PROGRAM)
-    message(STATUS "${LIBHAL_TITLE} clang-tidy not found.")
-  else()
-    # Set clang-tidy as a CXX language standard option
-    message(STATUS "${LIBHAL_TITLE} ${LIBHAL_CLANG_TIDY_PROGRAM} AVAILABLE!")
-    set(LIBHAL_CLANG_TIDY_CONFIG_FILE
-      "${LIBHAL_SCRIPT_PATH}/clang-tidy.conf")
-    set(LIBHAL_CLANG_TIDY "${LIBHAL_CLANG_TIDY_PROGRAM}"
-      "--config-file=${LIBHAL_CLANG_TIDY_CONFIG_FILE}")
-  endif()
-endif()
-
-# Adds clang tidy check to target for host builds (skipped if a cross build)
-function(_libhal_add_clang_tidy_check TARGET)
-  if(${CMAKE_CROSSCOMPILING})
-    message(STATUS "${LIBHAL_TITLE} Cross compiling, skipping clang-tidy checks for \"${TARGET}\"")
-  elseif(WIN32)
-    message(STATUS "${LIBHAL_TITLE} Windows has issues with clang-tidy, skipping clang-tidy checks for \"${TARGET}\"")
-  else()
-    set(CMAKE_CXX_CLANG_TIDY ${LIBHAL_CLANG_TIDY_PROGRAM})
-      set_target_properties(${TARGET} PROPERTIES CXX_CLANG_TIDY
-        "${LIBHAL_CLANG_TIDY}")
-  endif()
-endfunction()
-
 function(libhal_make_library)
   # Parse CMake function arguments
   set(options USE_CLANG_TIDY)

--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,7 @@ required_conan_version = ">=2.0.6"
 
 class libhal_cmake_util_conan(ConanFile):
     name = "libhal-cmake-util"
-    version = "4.2.0"
+    version = "4.3.0"
     license = "Apache-2.0"
     homepage = "https://libhal.github.io/libhal-armcortex"
     description = ("A collection of CMake scripts for ARM Cortex ")


### PR DESCRIPTION
clang-tidy is very annoying to work with in cmake. Adding any sort of flags that it doesn't understand results in breakages everywhere.

Rather than deal with clang-tidy, I'll push developers to call clangd-tidy directly. And have CI execute clangd-tidy as well. clangd-tidy runs clang-tidy via clangd which strips away all commands not meant for LLVM.