### PR TITLE
:heavy_plus_sign: Make `cmake` dependency of conanfile.py

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,8 +33,8 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: 📥 Install CMake & Conan
-        run: pipx install cmake conan==2.16.1
+      - name: 📥 Install Conan
+        run: pipx install conan==2.16.1
 
       - name: 📡 Add `libhal` conan remote
         run: conan remote add libhal

--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -52,7 +52,6 @@ function(libhal_make_library)
   endforeach()
 
   add_library(${LIBRARY_ARGS_LIBRARY_NAME} ${LIBRARY_ARGS_SOURCES})
-  _libhal_add_clang_tidy_check(${LIBRARY_ARGS_LIBRARY_NAME})
   target_include_directories(${LIBRARY_ARGS_LIBRARY_NAME} PUBLIC
     include
     src
@@ -108,8 +107,6 @@ function(libhal_unit_test)
   else()
     message(STATUS "${LIBHAL_TITLE} Address Sanitizer not supported!")
   endif(${ADDRESS_SANITIZER_SUPPORT})
-
-  _libhal_add_clang_tidy_check(unit_test)
 
   target_include_directories(unit_test PUBLIC include tests src
     ${UNIT_TEST_ARGS_INCLUDES})
@@ -189,7 +186,7 @@ endfunction()
 
 function(libhal_build_demos)
   # Parse CMake function arguments
-  set(options DISABLE_CLANG_TIDY)
+  set(options)
   set(one_value_args)
   set(multi_value_args
     DEMOS
@@ -257,10 +254,6 @@ function(libhal_build_demos)
       message(STATUS "${LIBHAL_TITLE} Found picolibc, linking it in!")
   endif()
 
-  if(NOT ${DEMO_ARGS_DISABLE_CLANG_TIDY})
-    _libhal_add_clang_tidy_check(startup_code)
-  endif()
-
   foreach(demo ${DEMO_ARGS_DEMOS})
     set(elf ${demo}.elf)
     message(STATUS "${LIBHAL_TITLE} Generating Demo for \"${elf}\"")
@@ -297,10 +290,6 @@ function(libhal_build_demos)
       # devices.
       libhal_post_build(${elf})
       libhal_disassemble(${elf})
-    endif()
-
-    if(NOT ${DEMO_ARGS_DISABLE_CLANG_TIDY})
-      _libhal_add_clang_tidy_check(${elf})
     endif()
   endforeach()
 endfunction()

--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,7 @@ required_conan_version = ">=2.0.6"
 
 class libhal_cmake_util_conan(ConanFile):
     name = "libhal-cmake-util"
-    version = "4.3.0"
+    version = "4.3.1"
     license = "Apache-2.0"
     homepage = "https://libhal.github.io/libhal-armcortex"
     description = ("A collection of CMake scripts for ARM Cortex ")
@@ -44,6 +44,9 @@ class libhal_cmake_util_conan(ConanFile):
 
     def layout(self):
         basic_layout(self)
+
+    def requirements(self):
+        self.tool_requires("cmake/[^3.10.0]")
 
     def package(self):
         copy(self, "LICENSE", dst=os.path.join(


### PR DESCRIPTION
- Remove cmake install in deploy.yml
- Ensure that a suitable version of cmake is available. I choose 3.10.0 arbitrarily. I believe our build scripts should work for that version. I simply wanted a number below the current used by most libhal libraries which is 3.16.x