### PR TITLE
:fire: Remove `LTO`` & `-f*-sections`` completely

### DIFF
--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -63,9 +63,6 @@ function(libhal_make_library)
     -Wall
     -Wextra
     -Wshadow
-    -ffunction-sections
-    -fdata-sections
-    -flto
     $<$<COMPILE_LANGUAGE:CXX>:-fexceptions -fno-rtti>)
   target_link_libraries(${LIBRARY_ARGS_LIBRARY_NAME} PUBLIC
     ${LIBRARY_ARGS_LINK_LIBRARIES})
@@ -119,8 +116,6 @@ function(libhal_unit_test)
     -Wextra
     -Wshadow
     -Wnon-virtual-dtor
-    -ffunction-sections
-    -fdata-sections
     -Wno-gnu-statement-expression
     -pedantic
     -g)
@@ -236,9 +231,6 @@ function(libhal_build_demos)
     -Wall
     -Wextra
     -Wshadow
-    -ffunction-sections
-    -fdata-sections
-    -flto
     ${DEMO_ARGS_COMPILE_FLAGS}
     $<$<COMPILE_LANGUAGE:CXX>:-fexceptions -fno-rtti>
   )
@@ -264,9 +256,6 @@ function(libhal_build_demos)
       -Wall
       -Wextra
       -Wshadow
-      -ffunction-sections
-      -fdata-sections
-      -flto
       ${DEMO_ARGS_COMPILE_FLAGS}
       $<$<COMPILE_LANGUAGE:CXX>:-fexceptions -fno-rtti>
     )

--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,7 @@ required_conan_version = ">=2.0.6"
 
 class libhal_cmake_util_conan(ConanFile):
     name = "libhal-cmake-util"
-    version = "4.3.1"
+    version = "4.3.2"
     license = "Apache-2.0"
     homepage = "https://libhal.github.io/libhal-armcortex"
     description = ("A collection of CMake scripts for ARM Cortex ")


### PR DESCRIPTION
Move optimization specific flags out of cmake-util and into the default compile profiles. This put more responsibility on the profile used and will reduce the surface area of responsibility for this package.