### PR TITLE
:bug: Fix ASAN conditional & deploy version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,8 +46,8 @@ jobs:
       - name: 👁️‍🗨️ Show conan profile
         run: conan profile show
 
-      - name: 📦 Create Conan Package
-        run: conan create .
+      - name: 📦 Create Conan Package version '${{ github.ref_name }}'
+        run: conan create . --version=${{ github.ref_name }}
 
       - name: 📡 Sign into JFrog Artifactory
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,8 +46,16 @@ jobs:
       - name: 👁️‍🗨️ Show conan profile
         run: conan profile show
 
-      - name: 📦 Create Conan Package version '${{ github.ref_name }}'
-        run: conan create . --version=${{ github.ref_name }}
+      - name: Set Version Environment Variable
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "VERSION=${{ github.ref_name }}" >> $GITHUB_ENV
+          else
+            echo "VERSION=latest" >> $GITHUB_ENV
+          fi
+
+      - name: 📦 Create Conan Package version '${{ env.VERSION }}'
+        run: conan create . --version=${{ env.VERSION }}
 
       - name: 📡 Sign into JFrog Artifactory
         if: startsWith(github.ref, 'refs/tags/')

--- a/cmake/build.cmake
+++ b/cmake/build.cmake
@@ -98,7 +98,7 @@ function(libhal_unit_test)
 
   # Enable ASAN only on non-Windows platforms
   # (Windows ASAN requires runtime DLL setup)
-  if(${ADDRESS_SANITIZER_SUPPORT} and NOT WIN32)
+  if(${ADDRESS_SANITIZER_SUPPORT} AND NOT WIN32)
     message(STATUS
     "${LIBHAL_TITLE} Address Sanitizer available! Using it for tests!")
     target_compile_options(unit_test PRIVATE -fsanitize=address)
@@ -106,7 +106,7 @@ function(libhal_unit_test)
   else()
     message(STATUS
     "${LIBHAL_TITLE} Address Sanitizer not supported or disabled on Windows!")
-  endif(${ADDRESS_SANITIZER_SUPPORT} and NOT WIN32)
+  endif(${ADDRESS_SANITIZER_SUPPORT} AND NOT WIN32)
 
   target_include_directories(unit_test PUBLIC include tests src
     ${UNIT_TEST_ARGS_INCLUDES})

--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,6 @@ required_conan_version = ">=2.0.6"
 
 class libhal_cmake_util_conan(ConanFile):
     name = "libhal-cmake-util"
-    version = "4.4.0"
     license = "Apache-2.0"
     homepage = "https://libhal.github.io/libhal-armcortex"
     description = ("A collection of CMake scripts for ARM Cortex ")


### PR DESCRIPTION
The release version and the conanfile.py version were misaligned. This change removes the version from the conanfile.py and lets deploy.yml select the version based on the ref_name. This will ensure that we only deploy on releases.