### PR TITLE
:bug: (patch) clang-tidy now runs correctly

### DIFF
--- a/v5/CMakeLists.txt
+++ b/v5/CMakeLists.txt
@@ -34,6 +34,7 @@ install(
 
 # Create a version file
 include(CMakePackageConfigHelpers)
+
 write_basic_package_version_file(
     "${CMAKE_CURRENT_BINARY_DIR}/LibhalCMakeUtilConfigVersion.cmake"
     VERSION 1.0.0

--- a/v5/cmake/LibhalBinUtils.cmake
+++ b/v5/cmake/LibhalBinUtils.cmake
@@ -31,7 +31,7 @@ function(libhal_create_hex_file_from TARGET_NAME)
 
     # Verify objcopy is available
     if(NOT CMAKE_OBJCOPY)
-        message(WARNING "objcopy not found - cannot generate hex file for ${TARGET_NAME}")
+        message(WARNING "‼️ objcopy not found - cannot generate hex file for ${TARGET_NAME}")
         return()
     endif()
 
@@ -73,7 +73,7 @@ function(libhal_create_binary_file_from TARGET_NAME)
 
     # Verify objcopy is available
     if(NOT CMAKE_OBJCOPY)
-        message(WARNING "objcopy not found - cannot generate binary file for ${TARGET_NAME}")
+        message(WARNING "‼️ objcopy not found - cannot generate binary file for ${TARGET_NAME}")
         return()
     endif()
 

--- a/v5/cmake/LibhalClangTidy.cmake
+++ b/v5/cmake/LibhalClangTidy.cmake
@@ -16,46 +16,46 @@
 
 # Options for controlling clang-tidy
 option(LIBHAL_ENABLE_CLANG_TIDY "Enable clang-tidy checks" OFF)
-option(LIBHAL_CLANG_TIDY_FIX "Apply clang-tidy fixes automatically" OFF)
+option(LIBHAL_CLANG_TIDY_FIX "Apply clang-tidy fixes automatically. If enabled, automatically enables clang-tidy." OFF)
 
 # Internal function to set up clang-tidy
 # Called by libhal_project_init()
 function(libhal_setup_clang_tidy)
     if(CMAKE_CROSSCOMPILING)
-        message(STATUS "Cross-compiling, skipping clang-tidy")
+        message(STATUS "🔄 Cross-compiling, skipping clang-tidy")
         return()
     endif()
-    
+
     if(NOT LIBHAL_ENABLE_CLANG_TIDY AND NOT LIBHAL_CLANG_TIDY_FIX)
-        message(STATUS "Clang-tidy disabled (use -DLIBHAL_ENABLE_CLANG_TIDY=ON to enable)")
+        message(STATUS "⚠️ Clang-tidy disabled. Use -DLIBHAL_ENABLE_CLANG_TIDY=ON to enable) or try -o '*:enable_clang_tidy=True' on conan packages with that option")
         return()
     endif()
-    
+
     find_program(CLANG_TIDY_EXE NAMES clang-tidy)
-    
+
     if(NOT CLANG_TIDY_EXE)
-        message(STATUS "Clang-tidy not found - continuing without it")
+        message(STATUS "❌ Clang-tidy not found - continuing without it")
         return()
     endif()
-    
-    message(STATUS "Clang-tidy found: ${CLANG_TIDY_EXE}")
-    
+
+    message(STATUS "✅ Clang-tidy found: ${CLANG_TIDY_EXE}")
+
     # Build the clang-tidy command
     set(CLANG_TIDY_CMD "${CLANG_TIDY_EXE}")
-    
+
     # Look for .clang-tidy file
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy")
         list(APPEND CLANG_TIDY_CMD "--config-file=${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy")
     endif()
-    
+
     # Add --fix if requested
     if(LIBHAL_CLANG_TIDY_FIX)
         list(APPEND CLANG_TIDY_CMD "--fix")
-        message(STATUS "Clang-tidy will apply fixes automatically")
+        message(STATUS "🛠️ Clang-tidy will apply fixes automatically")
     endif()
-    
+
     # Set the CMake variable to enable clang-tidy for all targets
-    set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_CMD} PARENT_SCOPE)
-    
-    message(STATUS "Clang-tidy enabled")
+    set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_CMD} CACHE STRING "clang-tidy command" FORCE)
+
+    message(STATUS "✅ Clang-tidy enabled!")
 endfunction()

--- a/v5/cmake/LibhalCompileOptions.cmake
+++ b/v5/cmake/LibhalCompileOptions.cmake
@@ -33,7 +33,7 @@ set(LIBHAL_ASAN_FLAGS
 # Convenience function to apply flags without remembering variable names
 function(libhal_apply_compile_options TARGET_NAME)
     if(NOT TARGET ${TARGET_NAME})
-        message(FATAL_ERROR "Target '${TARGET_NAME}' does not exist")
+        message(FATAL_ERROR "❌ Target '${TARGET_NAME}' does not exist")
     endif()
 
     target_compile_options(${TARGET_NAME} PRIVATE ${LIBHAL_CXX_FLAGS})
@@ -42,14 +42,14 @@ endfunction()
 
 function(libhal_apply_asan TARGET_NAME)
     if(NOT TARGET ${TARGET_NAME})
-        message(FATAL_ERROR "Target '${TARGET_NAME}' does not exist")
+        message(FATAL_ERROR "❌ Target '${TARGET_NAME}' does not exist")
     endif()
 
     if(NOT WIN32)
         target_compile_options(${TARGET_NAME} PRIVATE ${LIBHAL_ASAN_FLAGS})
         target_link_options(${TARGET_NAME} PRIVATE ${LIBHAL_ASAN_FLAGS})
-        message(STATUS "Applied AddressSanitizer to ${TARGET_NAME}")
+        message(STATUS "🛡️ Applied AddressSanitizer to ${TARGET_NAME}")
     else()
-        message(STATUS "AddressSanitizer not supported on Windows - skipping for ${TARGET_NAME}")
+        message(STATUS "🔄 AddressSanitizer not supported on Windows - skipping for ${TARGET_NAME}")
     endif()
 endfunction()

--- a/v5/cmake/LibhalExecutable.cmake
+++ b/v5/cmake/LibhalExecutable.cmake
@@ -87,7 +87,7 @@ function(libhal_build_apps)
     )
 
     if(NOT ARG_APPS)
-        message(FATAL_ERROR "APPS list is required")
+        message(FATAL_ERROR "❌ APPS list is required")
     endif()
 
     # Find packages once for all apps
@@ -98,28 +98,28 @@ function(libhal_build_apps)
     message(STATUS "Building apps:")
 
     # Create each app
-    foreach(DEMO_NAME IN LISTS ARG_APPS)
-        set(DEMO_FILE "apps/${DEMO_NAME}.cpp")
+    foreach(APP_NAME IN LISTS ARG_APPS)
+        set(APP_FILE "apps/${APP_NAME}.cpp")
 
         # Check if app file exists
-        if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${DEMO_FILE}")
-            message(WARNING "Demo file not found: ${DEMO_FILE}, skipping...")
+        if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${APP_FILE}")
+            message(WARNING "‼️ App file not found: ${APP_FILE}, skipping...")
             continue()
         endif()
 
         # Build the app sources list
-        set(DEMO_SOURCES ${DEMO_FILE})
+        set(DEMO_SOURCES ${APP_FILE})
         if(ARG_SOURCES)
             list(APPEND DEMO_SOURCES ${ARG_SOURCES})
         endif()
 
         # Create the app using the granular function
-        libhal_add_executable(${DEMO_NAME}
+        libhal_add_executable(${APP_NAME}
             SOURCES ${DEMO_SOURCES}
             INCLUDES ${ARG_INCLUDES}
             LINK_LIBRARIES ${ARG_LINK_LIBRARIES}
         )
 
-        message(STATUS "  - ${DEMO_NAME}")
+        message(STATUS "  - ${APP_NAME}")
     endforeach()
 endfunction()

--- a/v5/cmake/LibhalLibrary.cmake
+++ b/v5/cmake/LibhalLibrary.cmake
@@ -45,7 +45,7 @@ function(libhal_add_library TARGET_NAME)
     # Set C++23 standard for modules support
     target_compile_features(${TARGET_NAME} PUBLIC cxx_std_23)
 
-    message(STATUS "Created library: ${TARGET_NAME}")
+    message(STATUS "📦 Created library: ${TARGET_NAME}")
 endfunction()
 
 # Granular function: Install a library with CMake config
@@ -80,5 +80,5 @@ function(libhal_install_library TARGET_NAME)
         CXX_MODULES_DIRECTORY "cxx-modules"
     )
 
-    message(STATUS "Configured install for: ${TARGET_NAME} (namespace: ${ARG_NAMESPACE}::)")
+    message(STATUS "🎯 Configured install for: ${TARGET_NAME} (namespace: ${ARG_NAMESPACE}::)")
 endfunction()

--- a/v5/cmake/LibhalTesting.cmake
+++ b/v5/cmake/LibhalTesting.cmake
@@ -70,7 +70,7 @@ function(_libhal_add_tests_impl TARGET_NAME)
             list(APPEND TEST_LIST "tests/${NAME}.test.cpp")
         endforeach()
     else()
-        message(FATAL_ERROR "Either TEST_SOURCES or TEST_NAMES must be provided")
+        message(FATAL_ERROR "❌ Either TEST_SOURCES or TEST_NAMES must be provided")
     endif()
 
     # Find additional packages if specified

--- a/v5/conanfile.py
+++ b/v5/conanfile.py
@@ -37,14 +37,13 @@ class LibhalCMakeUtilConan(ConanFile):
         basic_layout(self)
 
     def package(self):
-        copy(self, "LICENSE",
-             dst=str(Path(self.package_folder) / "licenses"),
-             src=self.source_folder)
+        copy(self, "LICENSE", dst=self.package_folder, src=self.source_folder)
         copy(self, "cmake/*.cmake",
              src=self.source_folder,
              dst=self.package_folder)
 
     def package_info(self):
-        # Add cmake/ directory to builddirs so find_package(LibhalCMakeUtil) works
+        # Add cmake/ directory to builddirs so find_package(LibhalCMakeUtil)
+        # works
         cmake_dir = str(Path(self.package_folder) / "cmake")
         self.cpp_info.builddirs = [cmake_dir]


### PR DESCRIPTION
Propagating the variable up one scope fails to reach the project scope within libhal_project_init. We could propagate it again, but a better/easier solution would be to have the clang-tidy command must be set into the cmake cache.