### PR TITLE
:bug: (patch) Dynamically set library C++ std

### DIFF
--- a/v5/cmake/LibhalLibrary.cmake
+++ b/v5/cmake/LibhalLibrary.cmake
@@ -42,8 +42,9 @@ function(libhal_add_library TARGET_NAME)
         )
     endif()
 
-    # Set C++23 standard for modules support
-    target_compile_features(${TARGET_NAME} PUBLIC cxx_std_23)
+    # Attach C++ standard to package
+    target_compile_features(${TARGET_NAME} PUBLIC
+        "cxx_std_${CMAKE_CXX_STANDARD}")
 
     message(STATUS "📦 Created library: ${TARGET_NAME}")
 endfunction()


### PR DESCRIPTION
This sets the C++ version for the package to the C++ version of `CMAKE_CXX_STANDARD` which conan sets itself based on the profile. Without this change, only C++23 can be used with any packages that also uses modules.