### PR TITLE
:technologist: (patch) Enable clang-tidy support by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ What it does:
 
 - Enables compile_commands.json export
 - Checks for Ninja/Visual Studio generator (required for modules)
-- Sets up clang-tidy if enabled
+- Sets up clang-tidy (enabled by default, see [Clang-tidy](#clang-tidy))
 - Adds compile_commands.json copy target
 - Globally injects `-Qunused-arguments` into `CMAKE_CXX_FLAGS` for Clang/AppleClang
 
@@ -287,14 +287,24 @@ libhal_print_size_of(my_firmware)
 
 ## Clang-tidy
 
-Enable via CMake options:
+Clang-tidy checks are **enabled by default** (skipped automatically when
+cross-compiling, or when `clang-tidy` isn't found on `PATH`). Control it via
+CMake options:
 
 ```bash
-# Enable clang-tidy checks
-cmake -DLIBHAL_ENABLE_CLANG_TIDY=ON ..
+# Disable clang-tidy checks
+cmake -DLIBHAL_ENABLE_CLANG_TIDY=OFF ..
 
 # Enable with automatic fixes
 cmake -DLIBHAL_CLANG_TIDY_FIX=ON ..
+```
+
+Or at the start of your `CMakeList.txt` file:
+
+```cmake
+cmake_minimum_required(VERSION 4.0)
+
+set(LIBHAL_ENABLE_CLANG_TIDY OFF)
 ```
 
 ## Complete Examples

--- a/v5/cmake/LibhalClangTidy.cmake
+++ b/v5/cmake/LibhalClangTidy.cmake
@@ -15,7 +15,7 @@
 # Clang-tidy integration for libhal projects
 
 # Options for controlling clang-tidy
-option(LIBHAL_ENABLE_CLANG_TIDY "Enable clang-tidy checks" OFF)
+option(LIBHAL_ENABLE_CLANG_TIDY "Enable clang-tidy checks" ON)
 option(LIBHAL_CLANG_TIDY_FIX "Apply clang-tidy fixes automatically. If enabled, automatically enables clang-tidy." OFF)
 
 # Internal function to set up clang-tidy
@@ -27,7 +27,9 @@ function(libhal_setup_clang_tidy)
     endif()
 
     if(NOT LIBHAL_ENABLE_CLANG_TIDY AND NOT LIBHAL_CLANG_TIDY_FIX)
-        message(STATUS "⚠️ Clang-tidy disabled. Use -DLIBHAL_ENABLE_CLANG_TIDY=ON to enable) or try -o '*:enable_clang_tidy=True' on conan packages with that option")
+        message(STATUS "⚠️ Clang-tidy disabled")
+        message(STATUS "   To enable, pass -DLIBHAL_ENABLE_CLANG_TIDY=ON to your cmake command")
+        message(STATUS "   or add set(LIBHAL_ENABLE_CLANG_TIDY ON) to your CMakeLists.txt")
         return()
     endif()
 
@@ -51,11 +53,13 @@ function(libhal_setup_clang_tidy)
     # Add --fix if requested
     if(LIBHAL_CLANG_TIDY_FIX)
         list(APPEND CLANG_TIDY_CMD "--fix")
-        message(STATUS "🛠️ Clang-tidy will apply fixes automatically")
+        message(STATUS "🛠️ Clang-tidy fix ENABLED. Will apply fixes automatically...")
     endif()
 
     # Set the CMake variable to enable clang-tidy for all targets
     set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_CMD} CACHE STRING "clang-tidy command" FORCE)
 
     message(STATUS "✅ Clang-tidy enabled!")
+    message(STATUS "   To disable, pass -DLIBHAL_ENABLE_CLANG_TIDY=OFF to your cmake command")
+    message(STATUS "   or add set(LIBHAL_ENABLE_CLANG_TIDY OFF) to your CMakeLists.txt")
 endfunction()


### PR DESCRIPTION
Remove log stating that projects should have their own `enable_clang_tidy` option. This is more complicated than having it on by default and having an opt-out flag.