### PR TITLE
:sparkles: Add PACKAGE_NAME option to libhal_install_library, allow TEST_SOURCES alongside TEST_NAMES

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,20 @@ libhal_install_library(my_lib NAMESPACE libhal)
 Arguments:
 
 - `NAMESPACE` (optional) - Namespace for exported target (default: library name)
+- `PACKAGE_NAME` (optional) - Name used for `find_package()` and the installed
+  config file/directory (default: library name). Useful when the
+  `find_package()` name should differ from the linked target name, e.g. a
+  library target named `util` that should be discoverable as
+  `find_package(libhal-util)` while still linking as `libhal::util`:
+
+```cmake
+libhal_install_library(util NAMESPACE libhal PACKAGE_NAME libhal-util)
+```
+
+```cmake
+find_package(libhal-util REQUIRED CONFIG)
+target_link_libraries(my_app PRIVATE libhal::util)
+```
 
 ## Testing Functions
 

--- a/v5/cmake/LibhalLibrary.cmake
+++ b/v5/cmake/LibhalLibrary.cmake
@@ -54,12 +54,20 @@ endfunction()
 # Usage:
 #   libhal_install_library(my_lib NAMESPACE libhal)
 #   libhal_install_library(my_lib)  # Uses library name as namespace
+#   libhal_install_library(my_lib NAMESPACE libhal PACKAGE_NAME libhal-my-lib)
+#       # find_package(libhal-my-lib) resolves this package, while the linked
+#       # target remains libhal::my_lib
 function(libhal_install_library TARGET_NAME)
-    cmake_parse_arguments(ARG "" "NAMESPACE" "" ${ARGN})
+    cmake_parse_arguments(ARG "" "NAMESPACE;PACKAGE_NAME" "" ${ARGN})
 
     # Default namespace is the target name
     if(NOT ARG_NAMESPACE)
         set(ARG_NAMESPACE ${TARGET_NAME})
+    endif()
+
+    # Default package name (used for find_package()) is the target name
+    if(NOT ARG_PACKAGE_NAME)
+        set(ARG_PACKAGE_NAME ${TARGET_NAME})
     endif()
 
     # Install the library and its module files
@@ -75,12 +83,12 @@ function(libhal_install_library TARGET_NAME)
     # Install the CMake config files
     install(
         EXPORT ${TARGET_NAME}_targets
-        FILE "${TARGET_NAME}-config.cmake"
+        FILE "${ARG_PACKAGE_NAME}-config.cmake"
         NAMESPACE ${ARG_NAMESPACE}::
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${TARGET_NAME}"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${ARG_PACKAGE_NAME}"
         CXX_MODULES_DIRECTORY "cxx-modules"
         EXPORT_PACKAGE_DEPENDENCIES
     )
 
-    message(STATUS "🎯 Configured install for: ${TARGET_NAME} (namespace: ${ARG_NAMESPACE}::)")
+    message(STATUS "🎯 Configured install for: ${TARGET_NAME} (namespace: ${ARG_NAMESPACE}::, find_package: ${ARG_PACKAGE_NAME})")
 endfunction()

--- a/v5/cmake/LibhalTesting.cmake
+++ b/v5/cmake/LibhalTesting.cmake
@@ -74,9 +74,7 @@ generate a .dSYM debug info bundle" ON)
 
     # Determine test list
     set(TEST_LIST)
-    if(ARG_TEST_SOURCES)
-        set(TEST_LIST ${ARG_TEST_SOURCES})
-    elseif(ARG_TEST_NAMES)
+    if(ARG_TEST_NAMES)
         foreach(NAME IN LISTS ARG_TEST_NAMES)
             list(APPEND TEST_LIST "tests/${NAME}.test.cpp")
         endforeach()
@@ -106,10 +104,11 @@ generate a .dSYM debug info bundle" ON)
                 FILE_SET CXX_MODULES
                 TYPE CXX_MODULES
                 FILES ${ARG_MODULES}
-                PRIVATE ${TEST_FILE}
+                PRIVATE ${TEST_FILE} ${ARG_TEST_SOURCES}
             )
         else()
-            target_sources(${TEST_TARGET} PRIVATE ${TEST_FILE})
+            target_sources(${TEST_TARGET} PRIVATE
+                ${TEST_FILE} ${ARG_TEST_SOURCES})
         endif()
 
         # Configure test


### PR DESCRIPTION
libhal_install_library() now accepts an optional PACKAGE_NAME argument so the find_package() name can differ from the linked target name (e.g. target `util` linked as `libhal::util` but discoverable via find_package(libhal-util)).

libhal_add_tests() now merges ARG_TEST_SOURCES into the TEST_NAMES-generated file list instead of treating them as mutually exclusive.