### PR TITLE
Add libhal_apply_icf() for linker identical code folding

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,27 @@ nothing.
 
 This is recommended only for unit and integration tests.
 
+#### `libhal_apply_icf(TARGET_NAME)`
+
+Linker identical code folding for an executable target:
+
+```cmake
+libhal_apply_icf(my_app)
+```
+
+Folds functions that compile to identical machine code (a common result of
+template instantiation over structurally equivalent types, such as many
+libhal-org futures/tasks differing only in a pointer-sized template
+parameter) into a single copy in the final binary. Uses `--icf=safe` rather
+than `--icf=all`: `safe` only folds functions the linker can prove are
+interchangeable under all observable program behavior (including that
+nothing compares their addresses for identity), so it carries no correctness
+risk.
+
+This is an LLD-only flag and is gated to Clang/AppleClang, since this org's
+Clang toolchain is the one paired with LLD. It is safe to call on any
+toolchain; on a non-Clang compiler it applies no flags.
+
 ## Library Functions
 
 ### `libhal_add_library(TARGET_NAME)`

--- a/v5/cmake/LibhalCompileOptions.cmake
+++ b/v5/cmake/LibhalCompileOptions.cmake
@@ -30,6 +30,19 @@ set(LIBHAL_ASAN_FLAGS
     CACHE INTERNAL "libhal AddressSanitizer flags"
 )
 
+# --icf=safe only folds functions the linker can prove are interchangeable
+# under all observable program behavior (including that nothing compares
+# their addresses for identity), so it carries no correctness risk. This is
+# an LLD-only flag: it's gated to Clang/AppleClang because this org's Clang
+# toolchain (the `llvm-toolchain` Conan recipe) is the one paired with LLD;
+# GCC builds in this org do not necessarily link with LLD and should not
+# receive this flag.
+set(LIBHAL_ICF_FLAGS
+    $<$<CXX_COMPILER_ID:Clang,AppleClang>:
+        -Wl,--icf=safe>
+    CACHE INTERNAL "libhal linker identical code folding flags (LLD only)"
+)
+
 # Convenience function to apply flags without remembering variable names
 function(libhal_apply_compile_options TARGET_NAME)
     if(NOT TARGET ${TARGET_NAME})
@@ -52,4 +65,19 @@ function(libhal_apply_asan TARGET_NAME)
     else()
         message(STATUS "🔄 AddressSanitizer not supported on Windows - skipping for ${TARGET_NAME}")
     endif()
+endfunction()
+
+# Enables linker identical code folding on an executable target. Folds
+# functions that compile to identical machine code (a common result of
+# template instantiation over structurally equivalent types - for example,
+# coroutine/future wrapper types differing only in a pointer-sized template
+# parameter) into a single copy, reducing binary size. Safe to call
+# regardless of toolchain: on non-Clang compilers this applies no flags.
+function(libhal_apply_icf TARGET_NAME)
+    if(NOT TARGET ${TARGET_NAME})
+        message(FATAL_ERROR "❌ Target '${TARGET_NAME}' does not exist")
+    endif()
+
+    target_link_options(${TARGET_NAME} PRIVATE ${LIBHAL_ICF_FLAGS})
+    message(STATUS "🔗 Applied identical code folding to ${TARGET_NAME}")
 endfunction()


### PR DESCRIPTION
## Summary
- Adds `libhal_apply_icf(TARGET_NAME)`, an opt-in helper mirroring the existing `libhal_apply_asan()` pattern, that enables LLD's `--icf=safe` on an executable target.
- Gated to Clang/AppleClang via the same generator-expression pattern used elsewhere in this file, since `--icf` is an LLD flag and this org's Clang toolchain (`llvm-toolchain` Conan recipe) is the one paired with LLD.
- Uses `--icf=safe`, not `--icf=all`: `safe` only folds functions LLD can prove are interchangeable under all observable program behavior (including that nothing compares their addresses for identity), so it carries no correctness risk.
- Documents the new function in README.md alongside `libhal_apply_asan`.

## Motivation
Investigating ROM usage on a coroutine-heavy USB CDC demo (libhal-arm-mcu v2, stm32f103zg, Clang 20, MinSizeRel) found significant duplicate machine code from template instantiation over structurally equivalent types — e.g. `async::future<strong_ptr<X>>`'s wrapper methods compile to byte-identical bodies per distinct `X`, since `strong_ptr<T>`'s own refcounting logic is already fully type-erased and doesn't depend on `X`. The duplication comes purely from the outer template wrapper.

Measured on that demo (`.text` size):

| Configuration | size | vs. baseline |
|---|---|---|
| baseline | 74,893 B | — |
| `--icf=safe` (this PR) | 71,261 B | **−4.9%** |
| `--icf=all` (not proposed here) | 68,613 B | −8.4% |

`--icf=all` recovers more but was deliberately not chosen for this default helper given the address-identity risk described above.

Fixes #56

## Test plan
- [x] `cmake -P` syntax-checked the modified file.
- [x] Verified end-to-end through the real build: registered this checkout as a Conan editable, patched the resolved package cache, wired `libhal_apply_icf(usb)` into `libhal-arm-mcu`'s v2 demos `CMakeLists.txt`, rebuilt via the actual `conan-minsizerel` preset, and confirmed the `usb` demo's linked `.text` size matched the manually-measured `--icf=safe` figure above (71,261 B) exactly. That temporary wiring was reverted before this PR — it belongs in a separate, follow-up PR against `libhal-arm-mcu` (and other consuming repos) once this lands.
- [x] CI (format/lint) — will run on this PR.
